### PR TITLE
Fixed IndexError when using @staticmethod with *args combination

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -46,7 +46,8 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
             return
 
         if what in ('method', 'class'):
-            del argspec.args[0]
+            if argspec.args:
+                del argspec.args[0]
 
         return formatargspec(*argspec[:-1]), None
 


### PR DESCRIPTION
In this case with at least Python 3.4.3:

```
class Foo(object):
    @staticmethod
    def bar(*args):
        """Some docs"""
```

There is 

```
Exception occurred:
  File "/Users/anti1869/Sites/video/venv-v/lib/python3.4/site-packages/sphinx_autodoc_typehints.py", line 49, in process_signature
    del argspec.args[0]
IndexError: list assignment index out of range
```

As you can see from the trace, ``args`` is empty in ``FullArgSpec``.

```FullArgSpec(args=[], varargs='args', varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={})```

So I decided to add simple check.