### PR TITLE
google and numpy docstring support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ to this:
         return '{} {}'.format(value, unit)
 
 
+There is also support for google docstrings or numpy docstrings with help of the napoleon
+`napoleon sphinx extention http://sphinxcontrib-napoleon.readthedocs.io/en/latest/`_.
+
+
 Installation and setup
 ----------------------
 

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -1,5 +1,6 @@
 import inspect
-
+import logging
+import re
 from sphinx.util.inspect import getargspec
 from sphinx.ext.autodoc import formatargspec
 
@@ -7,6 +8,10 @@ try:
     from backports.typing import Optional, get_type_hints
 except ImportError:
     from typing import Optional, get_type_hints
+
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def format_annotation(annotation):
@@ -21,9 +26,14 @@ def format_annotation(annotation):
         if annotation.__module__ in ('typing', 'backports.typing'):
             if annotation.__qualname__ == 'Union':
                 params = annotation.__union_params__
-                if len(params) == 2 and params[1].__qualname__ == 'NoneType':
-                    annotation = Optional
-                    params = (params[0],)
+                if params[-1].__qualname__ == 'NoneType':
+                    if len(params) > 2:
+                        annotation.__union_params__ = params[:-1]
+                        params = (annotation,)
+                        annotation = Optional
+                    else:
+                        annotation = Optional
+                        params = (params[:-1],)
             else:
                 params = getattr(annotation, '__parameters__', None)
 
@@ -51,6 +61,105 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
         return formatargspec(obj, *argspec[:-1]), None
 
 
+def _process_google_docstrings(type_hints, lines):
+    """Process numpy docstrings parameters."""
+    for argname, annotation in type_hints.items():
+        formatted_annotation = format_annotation(annotation)
+
+        if argname == 'return':
+            pass
+        else:
+            logger.debug('Searching for %s', argname)
+            in_args_section = False
+            for i, line in enumerate(lines):
+                if line == 'Args:':
+                    in_args_section = True
+                elif in_args_section:
+                    if not line.startswith('  '):
+                        in_args_section = False
+                        break
+                    match = re.match('(  +{}) ?:(.*)'.format(argname), line)
+                    if match:
+                        lines[i] = match.expand('\\1 ({}): \\2'.format(str(formatted_annotation)))
+                        logger.debug('line replaced: %s', lines[i])
+                        break
+
+def _check_numpy_section_start(lines, i, section=None):
+    """Check if numpy section starts at line `i`"""
+    return (
+        i > 0 and
+        i < len(lines) - 1 and
+        lines[i + 1].startswith('---') and
+        (section and lines[i] == section or
+         re.match('\w+:', lines[i]))
+    )
+
+
+def _process_numpy_docstrings(type_hints, lines):
+    """Process numpy docstrings parameters."""
+    for argname, annotation in type_hints.items():
+        formatted_annotation = format_annotation(annotation)
+
+        if argname == 'return':
+            pass
+        else:
+            logger.debug('Searching for %s', argname)
+            in_args_section = False
+            in_return_section = False
+            for i, line in enumerate(lines):
+                if _check_numpy_section_start(lines, i - 1, 'Parameters'):
+                    logger.debug('Numpy parameters section ended on line %i', i)
+                    in_args_section = True
+                elif in_args_section:
+                    if _check_numpy_section_start(lines, i):
+                        in_args_section = False
+                        logger.debug('Numpy parameters section ended on line %i', i)
+                        break
+                    match = re.match('{}( ?: ?)?'.format(argname), line)
+                    if match:
+                        lines[i] = argname + ' : ' + formatted_annotation
+                        logger.debug('line replaced: %s', lines[i])
+                        break
+                elif (_check_numpy_section_start(lines, i, 'Returns') or
+                      _check_numpy_section_start(lines, i, 'Yields')):
+                    in_return_section = True
+                elif in_return_section:
+                    if _check_numpy_section_start(lines, i):
+                        in_return_section = False
+                        logger.debug('Numpy return section ended on line %i', i)
+                        break
+                    if lines[i - 1].startswith('---') and not line or line == ':':
+                        lines[i] = formatted_annotation
+                    if i < len(lines) - 1 and lines[i + 1].startswith('---') and re.match('\w+:', line):
+                        in_return_section = False
+                        logger.debug('Numpy parameters section ended on line %i', i)
+                        break
+
+
+def _process_sphinx_docstrings(type_hints, lines):
+    for argname, annotation in type_hints.items():
+        formatted_annotation = format_annotation(annotation)
+
+        if argname == 'return':
+            insert_index = len(lines)
+            for i, line in enumerate(lines):
+                if line.startswith(':rtype:'):
+                    insert_index = None
+                    break
+                elif line.startswith(':return:') or line.startswith(':returns:') or line.startswith(''):
+                    insert_index = i
+                    break
+
+            if insert_index is not None:
+                lines.insert(insert_index, ':rtype: {}'.format(formatted_annotation))
+        else:
+            searchfor = ':param {}:'.format(argname)
+            for i, line in enumerate(lines):
+                if line.startswith(searchfor):
+                    lines.insert(i, ':type {}: {}'.format(argname, formatted_annotation))
+                    break
+
+
 def process_docstring(app, what, name, obj, options, lines):
     if callable(obj):
         if what in ('class', 'exception'):
@@ -65,27 +174,10 @@ def process_docstring(app, what, name, obj, options, lines):
         except AttributeError:
             return
 
-        for argname, annotation in type_hints.items():
-            formatted_annotation = format_annotation(annotation)
+        _process_sphinx_docstrings(type_hints, lines)
+        _process_google_docstrings(type_hints, lines)
+        _process_numpy_docstrings(type_hints, lines)
 
-            if argname == 'return':
-                insert_index = len(lines)
-                for i, line in enumerate(lines):
-                    if line.startswith(':rtype:'):
-                        insert_index = None
-                        break
-                    elif line.startswith(':return:') or line.startswith(':returns:'):
-                        insert_index = i
-                        break
-
-                if insert_index is not None:
-                    lines.insert(insert_index, ':rtype: {}'.format(formatted_annotation))
-            else:
-                searchfor = ':param {}:'.format(argname)
-                for i, line in enumerate(lines):
-                    if line.startswith(searchfor):
-                        lines.insert(i, ':type {}: {}'.format(argname, formatted_annotation))
-                        break
 
 
 def setup(app):

--- a/tests/test_typehints_parser.py
+++ b/tests/test_typehints_parser.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+"""Small module to provide sourcecode for testing if everything works as needed
+
+"""
+
+from typing import Union, Optional, Iterable
+
+
+def format_unit(self, value: Union[float, int], unit: str, test: Optional[Union[Iterable, str]]) -> str:
+    """
+    Formats the given value as a human readable string using the given units.
+
+    :param value: a numeric value
+    :param unit: the unit for the value (kg, m, etc.)
+    :param test: bla bla blathe unit for the value (kg, m, etc.)
+    """
+    return '{} {}'.format(value, unit)
+
+
+def format_unit_google(self, value: Union[float, int], unit: str, test: Optional[Union[Iterable, str]]) -> str:
+    """
+    Formats the given value as a human readable string using the given units.
+
+    Args:
+        value: a numeric value
+        unit: the unit for the value (kg, m, etc.)
+        test: bla bla blathe unit for the value (kg, m, etc.)
+
+    Returns:
+       This function returns something of
+       value: and does not overwrite this part.
+    """
+    return '{} {}'.format(value, unit)
+
+
+def format_unit_numpy(self, value: Union[float, int], unit: str, test: Optional[Union[Iterable, str]]) -> str:
+    """
+    Formats the given value as a human readable string using the given units.
+
+    Parameters
+    ----------
+    value: a numeric value
+    unit: the unit for the value (kg, m, etc.)
+    test: bla bla blathe unit for the value (kg, m, etc.)
+
+    Returns
+    -------
+    This function returns something of
+    value: and does not overwrite this part.
+    """
+    return '{} {}'.format(value, unit)


### PR DESCRIPTION
Hi,
I needed to add support for the google docstring format for a different project.  
Since [napoleon](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/), the sphinx extension which enabled you to use google docstrings in the first place also supports numpy docstrings I thought I might add them as well. 
Let me know if you are interested in this, I'm also fine with maintaining this seperately for myself. 

In any case, thanks alot for making this in the first place!  