### PR TITLE
Removed return type of __init__ and fixed some generic type parameters missing.

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -78,7 +78,7 @@ def process_docstring(app, what, name, obj, options, lines):
 
             if argname == 'return':
                 if what in ('class', 'exception'):
-                    continue # Don't add return type None from __init__
+                    continue  # Don't add return type None from __init__
                 insert_index = len(lines)
                 for i, line in enumerate(lines):
                     if line.startswith(':rtype:'):

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -30,9 +30,14 @@ def format_annotation(annotation):
                 ellipsis = annotation.__tuple_use_ellipsis__
             else:
                 params = getattr(annotation, '__parameters__', None)
+                if not params:
+                    params = getattr(annotation, '__args__', None)
+                if params is Ellipsis:
+                    ellipsis = True
+                    params = []
 
-            if params:
-                formatted_params = list(format_annotation(param) for param in params)
+            if params or ellipsis:
+                formatted_params = list(format_annotation(param) for param in (params or []))
                 if ellipsis:
                     formatted_params.append('...')
                 extra = '\\[' + ', '.join(formatted_params) + ']'
@@ -76,6 +81,8 @@ def process_docstring(app, what, name, obj, options, lines):
             formatted_annotation = format_annotation(annotation)
 
             if argname == 'return':
+                if what in ('class', 'exception'):
+                    continue # Don't add return type None from __init__
                 insert_index = len(lines)
                 for i, line in enumerate(lines):
                     if line.startswith(':rtype:'):


### PR DESCRIPTION
Some generic types like `Mapping[str, int]` only have `__args__` but not `__parameters__`, so they didn't get the type arguments. Fixed that, but the generic arguments probably need a more general overhaul (when mixing generic and non-generic type parameters, this probably still doesn't work (e.g. for `Mapping[T, int]`).

Also, mypy forces you to have your `__init__` annotated with `-> None`, which was getting added to the docs. Removed that, because it is unnecessary and looks ugly.
