### PR TITLE
Reworked format_annotation()

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -18,19 +18,17 @@ except ImportError:
 
 def format_annotation(annotation, obj=None):
     if isinstance(annotation, type):
-        qname = sys.version_info[:2] >= (3, 3) and annotation.__qualname__ or annotation.__name__
-
         # builtin types don't need to be qualified with a module name
         if annotation.__module__ == 'builtins':
-            if qname == 'NoneType':
+            if annotation.__qualname__ == 'NoneType':
                 return '``None``'
             else:
-                return ':class:`%s`' % qname
+                return ':class:`%s`' % annotation.__qualname__
 
         params = None
 
         # Check first if we have an TypingMeta instance, because when mixing in another meta class,
-        # some informatiion might get lost.
+        # some information might get lost.
         # For example, a class inheriting from both tuple and Enum ends up not having the
         # TypingMeta metaclass and hence none of the Tuple typing information.
         if isinstance(annotation, TypingMeta):
@@ -66,7 +64,7 @@ def format_annotation(annotation, obj=None):
                     # Union[T,None]   => Optional[T]
                     # Union[T,U,None] => Optional[Union[T, U]]
                     if type(None) in (annotation.__union_set_params__ or tuple()):
-                        qname = 'Optional'
+                        annotation.__qualname__ = 'Optional'
                         params.remove(type(None))
                         if len(params) > 1:
                             params = [Union[tuple(params)]]
@@ -110,7 +108,7 @@ def format_annotation(annotation, obj=None):
                 return format_annotation(annotation.__type__, obj)
 
         generic = params and '\\[%s]' % ', '.join(format_annotation(p, obj) for p in params) or ''
-        return ':class:`~%s.%s`%s' % (annotation.__module__, qname, generic)
+        return ':class:`~%s.%s`%s' % (annotation.__module__, annotation.__qualname__, generic)
 
     # _TypeAlias is an internal class used for the Pattern/Match types
     # It represents an alias for another type, e.g. Pattern is an alias for any string type

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -26,7 +26,6 @@ def format_annotation(annotation, obj=None):
                 return ':class:`%s`' % annotation.__qualname__
 
         params = None
-
         # Check first if we have an TypingMeta instance, because when mixing in another meta class,
         # some information might get lost.
         # For example, a class inheriting from both tuple and Enum ends up not having the
@@ -35,16 +34,13 @@ def format_annotation(annotation, obj=None):
             # Since Any is a superclass of everything, make sure it gets handled normally.
             if annotation is Any:
                 pass
-
             # Generic classes have type arguments
             elif isinstance(annotation, GenericMeta):
                 params = annotation.__args__
-
                 # Make sure to format Generic[T, U, ...] correctly, because it only
                 # has parameters but nor argument values for them
                 if not params and issubclass(annotation, Generic):
                     params = annotation.__parameters__
-
             # Tuples are not Generics, so handle their type parameters separately.
             elif issubclass(annotation, Tuple):
                 if annotation.__tuple_params__:
@@ -55,7 +51,6 @@ def format_annotation(annotation, obj=None):
                     if params is None:
                         params = []
                     params.append(Ellipsis)
-
             # Unions are not Generics, so handle their type parameters separately.
             elif issubclass(annotation, Union):
                 if annotation.__union_params__:
@@ -68,7 +63,6 @@ def format_annotation(annotation, obj=None):
                         params.remove(type(None))
                         if len(params) > 1:
                             params = [Union[tuple(params)]]
-
             # Callables are not Generics, so handle their type parameters separately.
             # They have the format Callable[arg_types, return_type].
             # arg_types is either a list of types or an Ellipsis for Callables with
@@ -80,14 +74,11 @@ def format_annotation(annotation, obj=None):
                     else:
                         args_r = '\\[%s]' % ', '.join(format_annotation(a, obj)
                                                       for a in annotation.__args__)
-
                     params = [args_r, annotation.__result__]
-
             # Type variables are formatted with a prefix character (~, +, -)
             # which have to be escaped.
             elif isinstance(annotation, TypeVar):
                 return '\\' + repr(annotation)
-
             # Strings inside of type annotations are converted to _ForwardRef internally
             elif isinstance(annotation, _ForwardRef):
                 try:
@@ -101,7 +92,6 @@ def format_annotation(annotation, obj=None):
                     return format_annotation(actual_type, obj)
                 except SyntaxError:
                     return annotation.__forward_arg__
-
             # ClassVar is just a wrapper for another type to indicate it
             # annotates a class variable.
             elif ClassVar and issubclass(annotation, ClassVar):
@@ -109,13 +99,11 @@ def format_annotation(annotation, obj=None):
 
         generic = params and '\\[%s]' % ', '.join(format_annotation(p, obj) for p in params) or ''
         return ':class:`~%s.%s`%s' % (annotation.__module__, annotation.__qualname__, generic)
-
     # _TypeAlias is an internal class used for the Pattern/Match types
     # It represents an alias for another type, e.g. Pattern is an alias for any string type
     elif isinstance(annotation, _TypeAlias):
         actual_type = format_annotation(annotation.type_var, obj)
         return ':class:`~typing.%s`\\[%s]' % (annotation.name, actual_type)
-
     # Ellipsis is used in Callable/Tuple
     elif annotation is Ellipsis:
         return '...'

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -1,12 +1,12 @@
-from sphinx.util.inspect import getargspec
-from sphinx.ext.autodoc import formatargspec
-
 try:
     from backports.typing import (Any, Callable, Generic, GenericMeta, Tuple, TypeVar, TypingMeta,
                                   Union, _ForwardRef, _TypeAlias, get_type_hints)
 except ImportError:
     from typing import (Any, Callable, Generic, GenericMeta, Tuple, TypeVar, TypingMeta,
                         Union, _ForwardRef, _TypeAlias, get_type_hints)
+
+from sphinx.ext.autodoc import formatargspec
+from sphinx.util.inspect import getargspec
 
 
 def format_annotation(annotation, obj=None):

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -1,40 +1,120 @@
 import inspect
+import sys
 
 from sphinx.util.inspect import getargspec
 from sphinx.ext.autodoc import formatargspec
 
 try:
-    from backports.typing import Optional, get_type_hints
+    from backports.typing import (Any, Callable, Generic, GenericMeta, Tuple, TypeVar, TypingMeta,
+                                  Union, _ForwardRef, _TypeAlias, get_type_hints)
 except ImportError:
-    from typing import Optional, get_type_hints
+    from typing import (Any, Callable, Generic, GenericMeta, Tuple, TypeVar, TypingMeta,
+                        Union, _ForwardRef, _TypeAlias, get_type_hints)
 
+try:
+    from typing import ClassVar
+except ImportError:
+    ClassVar = None
 
-def format_annotation(annotation):
-    if inspect.isclass(annotation):
+    
+def format_annotation(annotation, obj=None):
+    if isinstance(annotation, type):
+        qname = sys.version_info[:2] >= (3, 3) and annotation.__qualname__ or annotation.__name__
+
+        # builtin types don't need to be qualified with a module name
         if annotation.__module__ == 'builtins':
-            if annotation.__qualname__ == 'NoneType':
+            if qname == 'NoneType':
                 return '``None``'
             else:
-                return ':class:`{}`'.format(annotation.__qualname__)
+                return ':class:`%s`' % qname
 
-        extra = ''
-        if annotation.__module__ in ('typing', 'backports.typing'):
-            if annotation.__qualname__ == 'Union':
-                params = annotation.__union_params__
-                if len(params) == 2 and params[1].__qualname__ == 'NoneType':
-                    annotation = Optional
-                    params = (params[0],)
-            elif annotation.__qualname__ == 'Tuple':
-                params = annotation.__tuple_params__
+        params = None
+
+        # Check first if we have an TypingMeta instance, because when mixing in another meta class,
+        # some informatiion might get lost.
+        # For example, a class inheriting from both tuple and Enum ends up not having the TypingMeta
+        # metaclass and hence none of the Tuple typing information.
+        if isinstance(annotation, TypingMeta):
+            # Since Any is a superclass of everything, make sure it gets handled normally.
+            if annotation is Any:
+                pass 
+
+            # Generic classes have type arguments
+            elif isinstance(annotation, GenericMeta):
+                params = annotation.__args__
+                
+                # Make sure to format Generic[T, U, ...] correctly, because it only
+                # has parameters but nor argument values for them
+                if not params and issubclass(annotation, Generic):
+                    params = annotation.__parameters__
+
+            # Tuples are not Generics, so handle their type parameters separately.
+            elif issubclass(annotation, Tuple):
+                if annotation.__tuple_params__:
+                    params = list(annotation.__tuple_params__)
+                # Tuples can have variable size with a fixed type, indicated by an Ellipsis: Tuple[T, ...].
                 if annotation.__tuple_use_ellipsis__:
-                    params += ('...',)
-            else:
-                params = getattr(annotation, '__parameters__', None)
+                    if params is None:
+                        params = []
+                    params.append(Ellipsis)
 
-            if params:
-                extra = '\\[' + ', '.join(format_annotation(param) for param in params) + ']'
+            # Unions are not Generics, so handle their type parameters separately.
+            elif issubclass(annotation, Union):
+                if annotation.__union_params__:
+                    params = list(annotation.__union_params__)
+                    # If the Union contains None, wrap it in an Optional, i.e.
+                    # Union[T,None]   => Optional[T]
+                    # Union[T,U,None] => Optional[Union[T, U]]
+                    if annotation.__union_set_params__ and type(None) in annotation.__union_set_params__:
+                        qname = 'Optional'
+                        params.remove(type(None))
+                        if len(params) > 1:
+                            params = [Union[tuple(params)]]
 
-        return ':class:`~{}.{}`{}'.format(annotation.__module__, annotation.__qualname__, extra)
+            # Callables are not Generics, so handle their type parameters separately.
+            # They have the format Callable[arg_types, return_type].
+            # arg_types is either a list of types or an Ellipsis for Callables with variable arguments.
+            elif issubclass(annotation, Callable):
+                if annotation.__args__ is not None or annotation.__result__ is not None:
+                    if annotation.__args__ is Ellipsis:
+                        args_r = Ellipsis
+                    else:
+                        args_r = '\\[%s]' % ', '.join(format_annotation(a, obj) for a in annotation.__args__)
+
+                    params = [args_r, annotation.__result__]
+
+            # Type variables are formatted with a prefix character (~, +, -) which has to be escaped.
+            elif isinstance(annotation, TypeVar):
+                return '\\' + repr(annotation)
+
+            # Strings inside of type annotations are converted to _ForwardRef internally
+            elif isinstance(annotation, _ForwardRef):
+                try:
+                    try:
+                        global_vars = obj is not None and obj.__globals__
+                    except AttributeError:
+                        global_vars = None
+                    # Evaluate the type annotation string and then format it
+                    actual_type = eval(annotation.__forward_arg__, global_vars) # pylint: disable=eval-used
+                    return format_annotation(actual_type, obj)
+                except SyntaxError:
+                    return annotation.__forward_arg__
+
+            # ClassVar is just a wrapper for another type to indicate it annotates a class variable.
+            elif ClassVar and issubclass(annotation, ClassVar):
+                return format_annotation(annotation.__type__, obj)
+
+        generic = params and '\\[%s]' % ', '.join(format_annotation(p, obj) for p in params) or ''
+        return ':class:`~%s.%s`%s' % (annotation.__module__, qname, generic)
+    
+    # _TypeAlias is an internal class used for the Pattern/Match types
+    # It represents an alias for another type, e.g. Pattern is an alias for any string type
+    elif isinstance(annotation, _TypeAlias):
+        return ':class:`~typing.%s`\\[%s]' % (annotation.name, format_annotation(annotation.type_var, obj))
+
+    # Ellipsis is used in Callable/Tuple
+    elif annotation is Ellipsis:
+        return '...'
 
     return str(annotation)
 
@@ -70,7 +150,7 @@ def process_docstring(app, what, name, obj, options, lines):
             return
 
         for argname, annotation in type_hints.items():
-            formatted_annotation = format_annotation(annotation)
+            formatted_annotation = format_annotation(annotation, obj)
 
             if argname == 'return':
                 insert_index = len(lines)

--- a/test_sphinx_autodoc_typehints.py
+++ b/test_sphinx_autodoc_typehints.py
@@ -2,6 +2,7 @@ from typing import (Any, Callable, Dict, Generic, Mapping, Optional, Pattern,
                     Tuple, Type, TypeVar, Union)
 
 import pytest
+
 from sphinx_autodoc_typehints import format_annotation
 
 T = TypeVar('T')
@@ -81,5 +82,3 @@ def test_format_annotation_with_obj():
 
     result = format_annotation(Type['A'], A)
     assert result == ':class:`~typing.Type`\\[A]'
-
-test_format_annotation_with_obj()

--- a/test_sphinx_autodoc_typehints.py
+++ b/test_sphinx_autodoc_typehints.py
@@ -1,0 +1,85 @@
+from typing import (Any, Callable, Dict, Generic, Mapping, Optional, Pattern,
+                    Tuple, Type, TypeVar, Union)
+
+import pytest
+from sphinx_autodoc_typehints import format_annotation
+
+T = TypeVar('T')
+U = TypeVar('U', covariant=True)
+V = TypeVar('V', contravariant=True)
+
+
+class A:
+    def get_type(self) -> Type['A']:
+        return type(self)
+
+
+class B(Generic[T]):
+    pass
+
+
+class C(Dict[T, int]):
+    pass
+
+
+@pytest.mark.parametrize('annotation, expected_result', [
+    (str,                           ':class:`str`'),
+    (int,                           ':class:`int`'),
+    (type(None),                    '``None``'),
+    (Any,                           ':class:`~typing.Any`'),
+    (Generic[T],                    ':class:`~typing.Generic`\\[\\~T]'),
+    (Mapping,                       ':class:`~typing.Mapping`\\[\\~KT, \\+VT_co]'),
+    (Mapping[T, int],               ':class:`~typing.Mapping`\\[\\~T, :class:`int`]'),
+    (Mapping[str, V],               ':class:`~typing.Mapping`\\[:class:`str`, \\-V]'),
+    (Mapping[T, U],                 ':class:`~typing.Mapping`\\[\\~T, \\+U]'),
+    (Mapping[str, bool],            ':class:`~typing.Mapping`\\[:class:`str`, :class:`bool`]'),
+    (Dict,                          ':class:`~typing.Dict`\\[\\~KT, \\~VT]'),
+    (Dict[T, int],                  ':class:`~typing.Dict`\\[\\~T, :class:`int`]'),
+    (Dict[str, V],                  ':class:`~typing.Dict`\\[:class:`str`, \\-V]'),
+    (Dict[T, U],                    ':class:`~typing.Dict`\\[\\~T, \\+U]'),
+    (Dict[str, bool],               ':class:`~typing.Dict`\\[:class:`str`, :class:`bool`]'),
+    (Tuple,                         ':class:`~typing.Tuple`'),
+    (Tuple[str, bool],              ':class:`~typing.Tuple`\\[:class:`str`, :class:`bool`]'),
+    (Tuple[int, int, int],          ':class:`~typing.Tuple`\\[:class:`int`, :class:`int`, '
+                                    ':class:`int`]'),
+    (Tuple[str, ...],               ':class:`~typing.Tuple`\\[:class:`str`, ...]'),
+    (Union,                         ':class:`~typing.Union`'),
+    (Union[str, bool],              ':class:`~typing.Union`\\[:class:`str`, :class:`bool`]'),
+    (Optional[str],                 ':class:`~typing.Optional`\\[:class:`str`]'),
+    (Optional[Union[int, str]],     ':class:`~typing.Optional`\\[:class:`~typing.Union`'
+                                    '\\[:class:`int`, :class:`str`]]'),
+    (Union[Optional[int], str],     ':class:`~typing.Optional`\\[:class:`~typing.Union`'
+                                    '\\[:class:`int`, :class:`str`]]'),
+    (Union[int, Optional[str]],     ':class:`~typing.Optional`\\[:class:`~typing.Union`'
+                                    '\\[:class:`int`, :class:`str`]]'),
+    (Callable,                      ':class:`~typing.Callable`'),
+    (Callable[..., int],            ':class:`~typing.Callable`\\[..., :class:`int`]'),
+    (Callable[[int], int],          ':class:`~typing.Callable`\\[\\[:class:`int`], :class:`int`]'),
+    (Callable[[int, str], bool],    ':class:`~typing.Callable`\\[\\[:class:`int`, :class:`str`], '
+                                    ':class:`bool`]'),
+    (Callable[[int, str], None],    ':class:`~typing.Callable`\\[\\[:class:`int`, :class:`str`], '
+                                    '``None``]'),
+    (Callable[[T], T],              ':class:`~typing.Callable`\\[\\[\\~T], \\~T]'),
+    (Pattern,                       ':class:`~typing.Pattern`\\[\\~AnyStr]'),
+    (Pattern[str],                  ':class:`~typing.Pattern`\\[:class:`str`]'),
+    (A,                             ':class:`~test.A`'),
+    (B,                             ':class:`~test.B`\\[\\~T]'),
+    (C,                             ':class:`~test.C`\\[\\~T]'),
+    (Type,                          ':class:`~typing.Type`\\[\\+CT]'),
+    (Type[A],                       ':class:`~typing.Type`\\[:class:`~test.A`]'),
+    (Type['A'],                     ':class:`~typing.Type`\\[A]'),
+    (Type['str'],                   ':class:`~typing.Type`\\[:class:`str`]'),
+])
+def test_format_annotation(annotation, expected_result):
+    result = format_annotation(annotation, None)
+    assert result == expected_result
+
+
+def test_format_annotation_with_obj():
+    result = format_annotation(Type['A'], A.get_type)
+    assert result == ':class:`~typing.Type`\\[:class:`~test.A`]'
+
+    result = format_annotation(Type['A'], A)
+    assert result == ':class:`~typing.Type`\\[A]'
+
+test_format_annotation_with_obj()

--- a/test_sphinx_autodoc_typehints.py
+++ b/test_sphinx_autodoc_typehints.py
@@ -62,11 +62,11 @@ class C(Dict[T, int]):
     (Callable[[T], T],              ':class:`~typing.Callable`\\[\\[\\~T], \\~T]'),
     (Pattern,                       ':class:`~typing.Pattern`\\[\\~AnyStr]'),
     (Pattern[str],                  ':class:`~typing.Pattern`\\[:class:`str`]'),
-    (A,                             ':class:`~test.A`'),
-    (B,                             ':class:`~test.B`\\[\\~T]'),
-    (C,                             ':class:`~test.C`\\[\\~T]'),
+    (A,                             ':class:`~%s.A`' % __name__),
+    (B,                             ':class:`~%s.B`\\[\\~T]' % __name__),
+    (C,                             ':class:`~%s.C`\\[\\~T]' % __name__),
     (Type,                          ':class:`~typing.Type`\\[\\+CT]'),
-    (Type[A],                       ':class:`~typing.Type`\\[:class:`~test.A`]'),
+    (Type[A],                       ':class:`~typing.Type`\\[:class:`~%s.A`]' % __name__),
     (Type['A'],                     ':class:`~typing.Type`\\[A]'),
     (Type['str'],                   ':class:`~typing.Type`\\[:class:`str`]'),
 ])
@@ -77,7 +77,7 @@ def test_format_annotation(annotation, expected_result):
 
 def test_format_annotation_with_obj():
     result = format_annotation(Type['A'], A.get_type)
-    assert result == ':class:`~typing.Type`\\[:class:`~test.A`]'
+    assert result == ':class:`~typing.Type`\\[:class:`~%s.A`]' % __name__
 
     result = format_annotation(Type['A'], A)
     assert result == ':class:`~typing.Type`\\[A]'


### PR DESCRIPTION
I reworked `format_annotation()` to work better with Generic types and correctly generate links for the type arguments. Some examples, that didn't work before:

``` python
Optional[Union[int, str]]
Callable[..., int]
Callable[[str, str], int]
Mapping[T, int]
Mapping[str, str]
```

Also string type hints now work correctly:

``` python
class A:
  def x(self) -> 'A':
    return self
```

This will generate a link to the A class now.
I can provide some tests for `format_annotation()` if you like.
