### PR TITLE
check for "__qualname__" attribute existence on union with ``Any``

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -57,7 +57,8 @@ def format_annotation(annotation):
             else:
                 params = annotation.__args__
 
-            if params and len(params) == 2 and params[1].__qualname__ == 'NoneType':
+            if params and len(params) == 2 and (hasattr(params[1], '__qualname__')
+                                                and params[1].__qualname__ == 'NoneType'):
                 class_name = 'Optional'
                 params = (params[0],)
         elif annotation_cls.__qualname__ == 'Tuple' and hasattr(annotation, '__tuple_params__'):

--- a/test_sphinx_autodoc_typehints.py
+++ b/test_sphinx_autodoc_typehints.py
@@ -59,6 +59,7 @@ class Slotted:
     (Tuple[str, ...],               ':class:`~typing.Tuple`\\[:class:`str`, ...]'),
     (Union,                         ':data:`~typing.Union`'),
     (Union[str, bool],              ':data:`~typing.Union`\\[:class:`str`, :class:`bool`]'),
+    (Union[str, Any],               ':data:`~typing.Union`\\[:class:`str`, :data:`~typing.Any`]'),
     (Optional[str],                 ':data:`~typing.Optional`\\[:class:`str`]'),
     (Callable,                      ':data:`~typing.Callable`'),
     (Callable[..., int],            ':data:`~typing.Callable`\\[..., :class:`int`]'),


### PR DESCRIPTION
Even thought it's debatable if it makes sense to have a union of a type other than ``Any`` and ``Any``, I came across it and encountered the error:

```
File "/home/python/lib/python3.6/site-packages/sphinx/ext/autodoc.py", line 695, in add_content
    for i, line in enumerate(self.process_doc(docstrings)):
  File "/home/python/lib/python3.6/site-packages/sphinx/ext/autodoc.py", line 657, in process_doc
    self.options, docstringlines)
  File "/home/python/lib/python3.6/site-packages/sphinx/application.py", line 551, in emit
    results.append(callback(self, *args))
  File "/home/python/lib/python3.6/site-packages/sphinx_autodoc_typehints.py", line 144, in process_docstring
    formatted_annotation = format_annotation(annotation)
  File "/home/python/lib/python3.6/site-packages/sphinx_autodoc_typehints.py", line 60, in format_annotation
    if params and len(params) == 2 and params[1].__qualname__ == 'NoneType':
AttributeError: '_Any' object has no attribute '__qualname__'
```

This pull request fixes the error and adds a regression test.