### PR TITLE
Avoid adding rtype directive if specified after return

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -152,7 +152,6 @@ def process_docstring(app, what, name, obj, options, lines):
                         break
                     elif line.startswith(':return:') or line.startswith(':returns:'):
                         insert_index = i
-                        break
 
                 if insert_index is not None:
                     lines.insert(insert_index, ':rtype: {}'.format(formatted_annotation))


### PR DESCRIPTION
The usual recommendation of ordering the return and rtype directives is
the return directive, then the rtype directive.

Previously, if users followed this recommendation, then an additional
rtype directive would be added before the return directive, resulting in
the return type showing twice in the resulting docs.