### PR TITLE
Fix for :rtype: being rendered in text

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -167,6 +167,12 @@ def process_docstring(app, what, name, obj, options, lines):
                         insert_index = i
 
                 if insert_index is not None:
+                    if insert_index == len(lines):
+                        # Ensure that :rtype: doesn't get joined with a paragraph of text, which
+                        # prevents it being interpreted.
+                        lines.append('')
+                        insert_index += 1
+
                     lines.insert(insert_index, ':rtype: {}'.format(formatted_annotation))
             else:
                 searchfor = ':param {}:'.format(argname)

--- a/tests/roots/test-dummy/conf.py
+++ b/tests/roots/test-dummy/conf.py
@@ -10,5 +10,6 @@ master_doc = 'index'
 
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx_autodoc_typehints',
     ]


### PR DESCRIPTION
Adds a blank line before :rtype: when it is appended. This ensures that
Sphinx doesn't interpret it as part of normal text.

I've only reproduced the problem when using sphinx.ext.napoleon (just
having it loaded is enough; one doesn't need to use numpydoc
formatting), so it's added to the test suite.