### PR TITLE
fixed rendering of generic types outside of the typing module

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -97,9 +97,12 @@ def format_annotation(annotation):
     elif inspect.isclass(annotation):
         extra = ''
         if isinstance(annotation, GenericMeta):
-            extra = '\\[{}]'.format(', '.join(format_annotation(param)
-                                              for param in annotation.__parameters__))
-
+            if getattr(annotation, '__parameters__', None):
+                extra = '\\[{}]'.format(', '.join(format_annotation(param)
+                                                  for param in annotation.__parameters__))
+            elif getattr(annotation, '__args__', None):
+                extra = '\\[{}]'.format(', '.join(format_annotation(arg)
+                                                  for arg in annotation.__args__))
         return ':py:class:`~{}.{}`{}'.format(annotation.__module__, annotation.__qualname__, extra)
     else:
         return str(annotation)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -76,7 +76,8 @@ class Slotted:
     (Pattern,                       ':py:class:`~typing.Pattern`\\[:py:data:`~typing.AnyStr`]'),
     (Pattern[str],                  ':py:class:`~typing.Pattern`\\[:py:class:`str`]'),
     (A,                             ':py:class:`~%s.A`' % __name__),
-    (B,                             ':py:class:`~%s.B`\\[\\~T]' % __name__)
+    (B,                             ':py:class:`~%s.B`\\[\\~T]' % __name__),
+    (B[int],                        ':py:class:`~%s.B`\\[:py:class:`int`]' % __name__)
 ])
 def test_format_annotation(annotation, expected_result):
     result = format_annotation(annotation)


### PR DESCRIPTION
See the added test for clarity -- without this change, it renders as "B[]", instead of "B[int]".