### PR TITLE
Fix exception when class has no documentation available

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -147,7 +147,7 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
             outer = inspect.getmodule(obj)
             for clsname in obj.__qualname__.split('.')[:-1]:
                 outer = getattr(outer, clsname)
-            method_object = outer.__dict__[obj.__name__]
+            method_object = outer.__dict__.get(obj.__name__)
             if not isinstance(method_object, (classmethod, staticmethod)):
                 del argspec.args[0]
 


### PR DESCRIPTION
I am using a third-party ([ArtifactoryPath](https://github.com/devopshq/artifactory)) that doesn't provide documentation. this means that the Sphinx cannot add a link to the documentation but it should be able to print the name of the class.

After enabling this plugin, the following snippet of code was throwing the below exception because of the return type `ArtifactoryPath`. This PR fixes the issue by returning None if the class is not present in the dictionary.
```python
    def __get_artifactory_path(self, path: str) -> ArtifactoryPath:
        """Get a remote Artifactory path from a relative path.

        :param path: The relative URL to request.
        :returns: remote Artifactory path.
        """
        url = "{b}/{d}".format(b=ArtifactManager.BaseUrl, d=path)
```

Exception:
```
Exception occurred:
  File "/home/benito/Engineering/python-env/lib/python3.6/site-packages/sphinx_autodoc_typehints.py", line 150, in process_signature
    method_object = outer.__dict__[obj.__name__]
KeyError: '__get_artifactory_path'
```