### PR TITLE
autodoc-process-signature chaining

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -169,7 +169,7 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
     result = app.emit_firstresult(AUTODOC_TYPEHINTS_PROCCESS_SIGNATURE_EVENT, what, name, obj, options, signature, return_annotation)
     
     if result:
-        signature, result_annotation = *result
+        signature, result_annotation = result
     
     return signature, return_annotation
 


### PR DESCRIPTION
I want to make some changes to the way my functions are rendered. Is it possible to register a call back like `autodoc-process-signature` to be called after `sphinx-autodoc-typehints` has finished its parsing?

Thanks.