### PR TITLE
Fix Sphinx deprecation warning: use "Signature" instead of "formatargspec"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 py_modules = sphinx_autodoc_typehints
 python_requires = !=3.5.0, !=3.5.1
 install_requires =
-    Sphinx >= 1.4
+    Sphinx >= 1.7
     typing >= 3.5; python_version == "3.4"
 
 [options.extras_require]


### PR DESCRIPTION
Fixes issue  #51 "formatargspec is deprecated"
All tests pass.
