### PR TITLE
Bump up minimum Sphinx version (fixes #59)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 py_modules = sphinx_autodoc_typehints
 python_requires = !=3.5.0, !=3.5.1
 install_requires =
-    Sphinx >= 1.7
+    Sphinx >= 1.8
     typing >= 3.5; python_version == "3.4"
 
 [options.extras_require]


### PR DESCRIPTION
As `sphinx_autodoc_typehints` now uses `config-inited` events introduced in Sphinx 1.8 (https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-config-inited), bump up the minimum required Sphinx version to 1.8.