### PR TITLE
Identify typing.NewType wrappers and construct annotation references

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -119,8 +119,8 @@ def format_annotation(annotation):
         return '...'
     elif (inspect.isfunction(annotation) and annotation.__module__ == 'typing' and
           hasattr(annotation, '__name__') and hasattr(annotation, '__supertype__')):
-        # NewType
-        return ':py:func:`~typing.NewType`\\(:py:data:`~{}`, {})'.format(annotation.__name__, format_annotation(annotation.__supertype__))
+        return ':py:func:`~typing.NewType`\\(:py:data:`~{}`, {})'.format(
+            annotation.__name__, format_annotation(annotation.__supertype__))
     elif inspect.isclass(annotation) or inspect.isclass(getattr(annotation, '__origin__', None)):
         if not inspect.isclass(annotation):
             annotation_cls = annotation.__origin__

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -111,6 +111,10 @@ def format_annotation(annotation):
         return '{}`~{}.{}`{}'.format(prefix, module, class_name, extra)
     elif annotation is Ellipsis:
         return '...'
+    elif (inspect.isfunction(annotation) and annotation.__module__ == 'typing' and
+          hasattr(annotation, '__name__') and hasattr(annotation, '__supertype__')):
+        # NewType
+        return ':py:func:`~typing.NewType`\\(:py:data:`~{}`, {})'.format(annotation.__name__, format_annotation(annotation.__supertype__))
     elif inspect.isclass(annotation) or inspect.isclass(getattr(annotation, '__origin__', None)):
         if not inspect.isclass(annotation):
             annotation_cls = annotation.__origin__

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -3,13 +3,15 @@ import pytest
 import sys
 import textwrap
 from typing import (
-    Any, AnyStr, Callable, Dict, Generic, Mapping, Optional, Pattern, Tuple, TypeVar, Union, Type)
+    Any, AnyStr, Callable, Dict, Generic, Mapping, NewType, Optional, Pattern,
+    Tuple, TypeVar, Union, Type)
 
 from sphinx_autodoc_typehints import format_annotation, process_docstring
 
 T = TypeVar('T')
 U = TypeVar('U', covariant=True)
 V = TypeVar('V', contravariant=True)
+W = NewType('W', str)
 
 
 class A:
@@ -71,7 +73,9 @@ class Slotted:
     (Pattern[str],                  ':py:class:`~typing.Pattern`\\[:py:class:`str`]'),
     (A,                             ':py:class:`~%s.A`' % __name__),
     (B,                             ':py:class:`~%s.B`\\[\\~T]' % __name__),
-    (B[int],                        ':py:class:`~%s.B`\\[:py:class:`int`]' % __name__)
+    (B[int],                        ':py:class:`~%s.B`\\[:py:class:`int`]' % __name__),
+    (W,                             ':py:func:`~typing.NewType`\\(:py:data:`~W`, '
+                                    ':py:class:`str`)'),
 ])
 def test_format_annotation(annotation, expected_result):
     result = format_annotation(annotation)


### PR DESCRIPTION
Resolves #41 producing output of the form `NewType(NewName, OldType)` with appropriate references.