### PR TITLE
Ignore callables defined as local functions

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -156,6 +156,12 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
         for param in signature.signature.parameters.values()
     ]
 
+    if '<locals>' in obj.__qualname__:
+        logger.warning(
+            'Cannot treat a function defined as a local function: "%s"  (use @functools.wraps)',
+            name)
+        return
+
     if parameters:
         if what in ('class', 'exception'):
             del parameters[0]

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -1,6 +1,14 @@
 import typing
 
 
+def get_local_function():
+    def wrapper(self) -> str:
+        """
+        Wrapper
+        """
+    return wrapper
+
+
 class Class:
     """
     Initializer docstring.
@@ -87,6 +95,8 @@ class Class:
 
             :param x: foo
             """
+
+    locally_defined_callable_field = get_local_function()
 
 
 class DummyException(Exception):

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -252,6 +252,13 @@ def test_sphinx_output(app, status, warning):
               Return type:
                  "str"
 
+           locally_defined_callable_field() -> str
+
+              Wrapper
+
+              Return type:
+                 "str"
+
         exception dummy_module.DummyException(message)
 
            Exception docstring


### PR DESCRIPTION
a pull request for #31

When such wrong callables found, this ignore them and prints a warning which recommends `functools.wraps`.