### PR TITLE
Allow users to strip annotations from signatures without modifying docstrings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,9 @@ The following configuration options are accepted:
 * ``set_type_checking_flag`` (default: ``False``): if ``True``, set ``typing.TYPE_CHECKING`` to
   ``True`` to enable "expensive" typing imports
 
+* ``add_type_hints_to_docstring`` (default: ``True``): if ``True``, insert parameter types from the
+  signatures of callable objects into their docstrings
+
 
 How it works
 ------------

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Options
 
 The following configuration options are accepted:
 
-* ``set_type_checking_flag`` (default: ``True``): if ``True``, set ``typing.TYPE_CHECKING`` to
+* ``set_type_checking_flag`` (default: ``False``): if ``True``, set ``typing.TYPE_CHECKING`` to
   ``True`` to enable "expensive" typing imports
 
 

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -184,6 +184,9 @@ def process_signature(app, what: str, name: str, obj, options, signature, return
 
 
 def process_docstring(app, what, name, obj, options, lines):
+    if app and not app.config.add_type_hints_to_docstring:
+        return
+
     if isinstance(obj, property):
         obj = obj.fget
 
@@ -244,6 +247,7 @@ def builder_ready(app):
 
 def setup(app):
     app.add_config_value('set_type_checking_flag', False, 'html')
+    app.add_config_value('add_type_hints_to_docstring', True, 'html')
     app.connect('builder-inited', builder_ready)
     app.connect('autodoc-process-signature', process_signature)
     app.connect('autodoc-process-docstring', process_docstring)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -117,7 +117,10 @@ def test_process_docstring_slot_wrapper():
 
 
 def test_add_type_hints_to_docstring_option(monkeypatch):
-    class Dummy(object): pass
+
+    class Dummy(object):
+        pass
+
     class App(object):
         """
         Mock app object for testing.
@@ -127,6 +130,7 @@ def test_add_type_hints_to_docstring_option(monkeypatch):
         def __init__(self, value: bool):
             self.config = Dummy()
             self.config.add_type_hints_to_docstring = value
+
     # ensure :type ...: is added when option is True
     lines = inspect.cleandoc(App.__doc__).splitlines()
     process_docstring(App(True), 'class', 'App', App, None, lines)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -5,6 +5,7 @@ import textwrap
 from typing import (
     Any, AnyStr, Callable, Dict, Generic, Mapping, NewType, Optional, Pattern,
     Tuple, TypeVar, Union, Type)
+import inspect
 
 from typing_extensions import Protocol
 
@@ -113,6 +114,27 @@ def test_process_docstring_slot_wrapper():
     lines = []
     process_docstring(None, 'class', 'SlotWrapper', Slotted, None, lines)
     assert not lines
+
+
+def test_add_type_hints_to_docstring_option(monkeypatch):
+    class Dummy(object): pass
+    class App(object):
+        """
+        Mock app object for testing.
+
+        :param value: The value to set `config.add_type_hints_to_docstring`
+        """
+        def __init__(self, value: bool):
+            self.config = Dummy()
+            self.config.add_type_hints_to_docstring = value
+    # ensure :type ...: is added when option is True
+    lines = inspect.cleandoc(App.__doc__).splitlines()
+    process_docstring(App(True), 'class', 'App', App, None, lines)
+    assert ':type value: :py:class:`bool`' in lines
+    # ensure :type ...: is not added when option is False
+    lines = inspect.cleandoc(App.__doc__).splitlines()
+    process_docstring(App(False), 'class', 'App', App, None, lines)
+    assert ':type value: :py:class:`bool`' not in lines
 
 
 @pytest.mark.sphinx('text', testroot='dummy')


### PR DESCRIPTION
Some users may wish to use type hints in their code for purposes other than Sphinx documentation, and sphinx-autodoc-typehints is useful for stripping the annotations out of the signatures when autodoc is used, but there was no way to prevent sphinx-autodoc-typehints from also modifying the docstrings. This PR adds a new option `add_type_hints_to_docstring` which defaults to `True` (thus not changing the current behavior) but can be set to `False` to prevent any modification to the docstrings.