### PR TITLE
feat: Add type hint comment support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires = Sphinx >= 2.1
 test =
     pytest >= 3.1.0
     typing_extensions >= 3.5
+    typed_ast >= 1.4.0
 
 [flake8]
 max-line-length = 99

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -272,7 +272,7 @@ def backfill_type_hints(obj, name):
     if comment_returns:
         rv['return'] = comment_returns
 
-    if comment_args_str != '(...)':
+    if comment_args_str not in ('()', '(...)'):
         logger.warning(
             'Only supporting `type: (...) -> rv`-style type hint comments, '
             'skipping types for "%s"',

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -250,9 +250,8 @@ def get_all_type_hints(obj, name):
 
     if comment_args == ['...']:
         comment_args = [None] * len(args)
-    elif len(comment_args) != len(args):
-        logger.warning('Wrong argument count in type hint comment for "%s"', name)
-        return rv
+    elif len(args) > len(comment_args):
+        comment_args = [None] * (len(args) - len(comment_args)) + comment_args
 
     rv['return'] = comment_returns
 

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -217,7 +217,11 @@ def get_all_type_hints(obj, name):
         return rv
 
     if len(obj_ast) != 1:
-        logger.warning('Did not get exactly one node from AST for "%s", got %s', name, len(obj_ast))
+        logger.warning(
+            'Did not get exactly one node from AST for "%s", got %s',
+            name,
+            len(obj_ast)
+        )
         return rv
 
     obj_ast = obj_ast[0]

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -138,12 +138,25 @@ def function_with_unresolvable_annotation(x: 'a.b.c'):
     """
 
 
-def function_with_typehint_comment(x):
-    # type: (int) -> None
+def function_with_typehint_comment(x, y):
+    # type: (int, str) -> None
     """
     Function docstring.
 
     :param x: foo
+    :param y: bar
+    """
+
+def function_with_inline_typehint_comment(
+    x,  # type: int
+    y   # type: str
+):
+    # type: (...) -> None
+    """
+    Function docstring.
+
+    :param x: foo
+    :param y: bar
     """
 
 

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -138,16 +138,8 @@ def function_with_unresolvable_annotation(x: 'a.b.c'):
     """
 
 
-def function_with_typehint_comment(x, y):
-    # type: (int, str) -> None
-    """
-    Function docstring.
 
-    :param x: foo
-    :param y: bar
-    """
-
-def function_with_inline_typehint_comment(
+def function_with_typehint_comment(
     x,  # type: int
     y   # type: str
 ):
@@ -167,12 +159,18 @@ class ClassWithTypehints(object):
     :param x: foo
     """
 
-    def __init__(self, x):
-        # type: (int) -> None
+    def __init__(
+        self,
+        x  # type: int
+    ):
+        # type: (...) -> None
         pass
 
-    def foo(self, x):
-        # type: (str) -> int
+    def foo(
+        self,
+        x  # type: str
+    ):
+        # type: (...) -> int
         """
         Method docstring.
 

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -136,3 +136,33 @@ def function_with_unresolvable_annotation(x: 'a.b.c'):
 
     :param x: foo
     """
+
+
+def function_with_typehint_comment(x):
+    # type: (int) -> None
+    """
+    Function docstring.
+
+    :param x: foo
+    """
+
+
+class ClassWithTypehints(object):
+    """
+    Class docstring.
+
+    :param x: foo
+    """
+
+    def __init__(self, x):
+        # type: (int) -> None
+        pass
+
+    def foo(self, x):
+        # type: (str) -> int
+        """
+        Method docstring.
+
+        :param x: foo
+        """
+        return 42

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -16,3 +16,8 @@ Dummy Module
 .. autofunction:: dummy_module.function_with_escaped_default
 
 .. autofunction:: dummy_module.function_with_unresolvable_annotation
+
+.. autofunction:: dummy_module.function_with_typehint_comment
+
+.. autoclass:: dummy_module.ClassWithTypehints
+   :members:

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -19,7 +19,5 @@ Dummy Module
 
 .. autofunction:: dummy_module.function_with_typehint_comment
 
-.. autofunction:: dummy_module.function_with_inline_typehint_comment
-
 .. autoclass:: dummy_module.ClassWithTypehints
    :members:

--- a/tests/roots/test-dummy/index.rst
+++ b/tests/roots/test-dummy/index.rst
@@ -19,5 +19,7 @@ Dummy Module
 
 .. autofunction:: dummy_module.function_with_typehint_comment
 
+.. autofunction:: dummy_module.function_with_inline_typehint_comment
+
 .. autoclass:: dummy_module.ClassWithTypehints
    :members:

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -302,39 +302,39 @@ def test_sphinx_output(app, status, warning):
            Function docstring.
 
            Parameters:
-              * **x** (*int*) – foo
+              * **x** ("int") – foo
 
-              * **y** (*str*) – bar
+              * **y** ("str") – bar
 
            Return type:
-              None
+              "None"
 
         dummy_module.function_with_inline_typehint_comment(x, y)
 
            Function docstring.
 
            Parameters:
-              * **x** (*int*) – foo
+              * **x** ("int") – foo
 
-              * **y** (*str*) – bar
+              * **y** ("str") – bar
 
            Return type:
-              None
+              "None"
 
         class dummy_module.ClassWithTypehints(x)
 
            Class docstring.
 
            Parameters:
-              **x** (*int*) -- foo
+              **x** ("int") -- foo
 
            foo(x)
 
               Method docstring.
 
               Parameters:
-                 **x** (*str*) -- foo
+                 **x** ("str") -- foo
 
               Return type:
-                 int
+                 "int"
         ''').replace('–', '--')

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -297,12 +297,26 @@ def test_sphinx_output(app, status, warning):
            Parameters:
               **x** (*a.b.c*) – foo
 
-        dummy_module.function_with_typehint_comment(x)
+        dummy_module.function_with_typehint_comment(x, y)
 
            Function docstring.
 
            Parameters:
-              **x** (*int*) – foo
+              * **x** (*int*) – foo
+
+              * **y** (*str*) – bar
+
+           Return type:
+              None
+
+        dummy_module.function_with_inline_typehint_comment(x, y)
+
+           Function docstring.
+
+           Parameters:
+              * **x** (*int*) – foo
+
+              * **y** (*str*) – bar
 
            Return type:
               None
@@ -312,12 +326,15 @@ def test_sphinx_output(app, status, warning):
            Class docstring.
 
            Parameters:
-              **x** -- foo
+              **x** (*int*) -- foo
 
            foo(x)
 
               Method docstring.
 
               Parameters:
-                 **x** -- foo
+                 **x** (*str*) -- foo
+
+              Return type:
+                 int
         ''').replace('–', '--')

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -296,4 +296,28 @@ def test_sphinx_output(app, status, warning):
 
            Parameters:
               **x** (*a.b.c*) – foo
+
+        dummy_module.function_with_typehint_comment(x)
+
+           Function docstring.
+
+           Parameters:
+              **x** (*int*) – foo
+
+           Return type:
+              None
+
+        class dummy_module.ClassWithTypehints(x)
+
+           Class docstring.
+
+           Parameters:
+              **x** -- foo
+
+           foo(x)
+
+              Method docstring.
+
+              Parameters:
+                 **x** -- foo
         ''').replace('–', '--')

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -309,18 +309,6 @@ def test_sphinx_output(app, status, warning):
            Return type:
               "None"
 
-        dummy_module.function_with_inline_typehint_comment(x, y)
-
-           Function docstring.
-
-           Parameters:
-              * **x** ("int") – foo
-
-              * **y** ("str") – bar
-
-           Return type:
-              "None"
-
         class dummy_module.ClassWithTypehints(x)
 
            Class docstring.


### PR DESCRIPTION
Fix #13

I've made it so that there's as little risk of regression as possible for existing users by shortcutting to `get_type_hints` or `__annotations__` if that approach works. If those return empty mappings, use `typed_ast` with `inspect.getsource` to get type hint comments. An additional advantage is that `typed_ast` is only an optional dependency just for type hint comments.