### PR TITLE
Catch recursion errors when getting type hints

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -191,8 +191,9 @@ def get_all_type_hints(obj, name):
 
     try:
         rv = get_type_hints(obj)
-    except (AttributeError, TypeError):
-        # Introspecting a slot wrapper will raise TypeError
+    except (AttributeError, TypeError, RecursionError):
+        # Introspecting a slot wrapper will raise TypeError, and and some recursive type definitions
+        # will cause a RecursionError (see: https://github.com/python/typing/issues/574).
         pass
     except NameError as exc:
         logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -192,8 +192,8 @@ def get_all_type_hints(obj, name):
     try:
         rv = get_type_hints(obj)
     except (AttributeError, TypeError, RecursionError):
-        # Introspecting a slot wrapper will raise TypeError, and and some recursive type definitions
-        # will cause a RecursionError (see: https://github.com/python/typing/issues/574).
+        # Introspecting a slot wrapper will raise TypeError, and and some recursive type
+        # definitions # will cause a RecursionError (https://github.com/python/typing/issues/574).
         pass
     except NameError as exc:
         logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -193,7 +193,7 @@ def get_all_type_hints(obj, name):
         rv = get_type_hints(obj)
     except (AttributeError, TypeError, RecursionError):
         # Introspecting a slot wrapper will raise TypeError, and and some recursive type
-        # definitions # will cause a RecursionError (https://github.com/python/typing/issues/574).
+        # definitions will cause a RecursionError (https://github.com/python/typing/issues/574).
         pass
     except NameError as exc:
         logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',


### PR DESCRIPTION
There's an [upstream issue](https://github.com/python/typing/issues/574) which is causing documentation building to fail when recursive type definitions are used. This catches `RecursionError` exceptions when calling `typing.get_type_hints()` so that the build can proceed.

Closes #91