### PR TITLE
Create correct links for more (all?) typing.* types.

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -2,7 +2,12 @@ import builtins
 import inspect
 import textwrap
 import typing
-from typing import get_type_hints, TypeVar, ClassVar, Any, AnyStr, Generic, NoReturn, Union
+from typing import get_type_hints, TypeVar, Any, AnyStr, Generic, Union
+try:  # Those aren’t available on Ubuntu Xenial’s Python 3.5.1
+    from typing import ClassVar, NoReturn
+except ImportError:
+    ClassVar = type('ClassVar', (object,), {})
+    NoReturn = type('NoReturn', (object,), {})
 
 from sphinx.util import logging
 from sphinx.util.inspect import Signature

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -4,8 +4,8 @@ import sys
 import textwrap
 from typing import (
     Any, AnyStr, Callable, ClassVar, Dict, Generic,
-    Mapping, NewType, NoReturn, Optional, Pattern,
-    Tuple, Type, TypeVar, Union,
+    List, Mapping, NewType, NoReturn, Optional, Pattern,
+    Set, TextIO, Tuple, Type, TypeVar, Union,
 )
 
 from typing_extensions import Protocol
@@ -63,6 +63,10 @@ class Slotted:
     (Dict[T, U],                    ':py:class:`~typing.Dict`\\[\\~T, \\+U]'),
     (Dict[str, bool],               ':py:class:`~typing.Dict`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
+    (List,                          ':py:class:`~typing.List`\\[\\~T]'),
+    (List[int],                     ':py:class:`~typing.List`\\[:py:class:`int`]'),
+    (Set,                           ':py:class:`~typing.Set`\\[\\~T]'),
+    (Set[int],                      ':py:class:`~typing.Set`\\[:py:class:`int`]'),
     (Tuple,                         ':py:data:`~typing.Tuple`'),
     (Tuple[str, bool],              ':py:data:`~typing.Tuple`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
@@ -90,6 +94,7 @@ class Slotted:
     (Pattern[str],                  ':py:class:`~typing.Pattern`\\[:py:class:`str`]'),
     (ClassVar,                      ':py:data:`~typing.ClassVar`'),
     (ClassVar[str],                 ':py:data:`~typing.ClassVar`\\[:py:class:`str`]'),
+    (TextIO,                        ':py:class:`~typing.TextIO`'),
     (A,                             ':py:class:`~%s.A`' % __name__),
     (B,                             ':py:class:`~%s.B`\\[\\~T]' % __name__),
     (B[int],                        ':py:class:`~%s.B`\\[:py:class:`int`]' % __name__),

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -3,14 +3,16 @@ import pytest
 import sys
 import textwrap
 from typing import (
-    Any, AnyStr, Callable, ClassVar, Dict, Generic,
-    List, Mapping, NewType, NoReturn, Optional, Pattern,
+    Any, AnyStr, Callable, Dict, Generic,
+    List, Mapping, NewType, Optional, Pattern,
     Set, TextIO, Tuple, Type, TypeVar, Union,
 )
 
 from typing_extensions import Protocol
 
 from sphinx_autodoc_typehints import format_annotation, process_docstring
+# Those aren’t available in `typing` from Ubuntu Xenial’s Python 3.5.1
+from sphinx_autodoc_typehints import ClassVar, NoReturn
 
 T = TypeVar('T')
 U = TypeVar('U', covariant=True)

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -3,8 +3,10 @@ import pytest
 import sys
 import textwrap
 from typing import (
-    Any, AnyStr, Callable, Dict, Generic, Mapping, NewType, Optional, Pattern,
-    Tuple, TypeVar, Union, Type)
+    Any, AnyStr, Callable, ClassVar, Dict, Generic,
+    Mapping, NewType, NoReturn, Optional, Pattern,
+    Tuple, Type, TypeVar, Union,
+)
 
 from typing_extensions import Protocol
 
@@ -47,6 +49,7 @@ class Slotted:
     (type(None),                    '``None``'),
     (Any,                           ':py:data:`~typing.Any`'),
     (AnyStr,                        ':py:data:`~typing.AnyStr`'),
+    (NoReturn,                      ':py:data:`~typing.NoReturn`'),
     (Generic[T],                    ':py:class:`~typing.Generic`\\[\\~T]'),
     (Mapping,                       ':py:class:`~typing.Mapping`\\[\\~KT, \\+VT_co]'),
     (Mapping[T, int],               ':py:class:`~typing.Mapping`\\[\\~T, :py:class:`int`]'),
@@ -60,12 +63,12 @@ class Slotted:
     (Dict[T, U],                    ':py:class:`~typing.Dict`\\[\\~T, \\+U]'),
     (Dict[str, bool],               ':py:class:`~typing.Dict`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
-    (Tuple,                         ':py:class:`~typing.Tuple`'),
-    (Tuple[str, bool],              ':py:class:`~typing.Tuple`\\[:py:class:`str`, '
+    (Tuple,                         ':py:data:`~typing.Tuple`'),
+    (Tuple[str, bool],              ':py:data:`~typing.Tuple`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
-    (Tuple[int, int, int],          ':py:class:`~typing.Tuple`\\[:py:class:`int`, '
+    (Tuple[int, int, int],          ':py:data:`~typing.Tuple`\\[:py:class:`int`, '
                                     ':py:class:`int`, :py:class:`int`]'),
-    (Tuple[str, ...],               ':py:class:`~typing.Tuple`\\[:py:class:`str`, ...]'),
+    (Tuple[str, ...],               ':py:data:`~typing.Tuple`\\[:py:class:`str`, ...]'),
     (Union,                         ':py:data:`~typing.Union`'),
     (Union[str, bool],              ':py:data:`~typing.Union`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
@@ -85,6 +88,8 @@ class Slotted:
     (Callable[[T], T],              ':py:data:`~typing.Callable`\\[\\[\\~T], \\~T]'),
     (Pattern,                       ':py:class:`~typing.Pattern`\\[:py:data:`~typing.AnyStr`]'),
     (Pattern[str],                  ':py:class:`~typing.Pattern`\\[:py:class:`str`]'),
+    (ClassVar,                      ':py:data:`~typing.ClassVar`'),
+    (ClassVar[str],                 ':py:data:`~typing.ClassVar`\\[:py:class:`str`]'),
     (A,                             ':py:class:`~%s.A`' % __name__),
     (B,                             ':py:class:`~%s.B`\\[\\~T]' % __name__),
     (B[int],                        ':py:class:`~%s.B`\\[:py:class:`int`]' % __name__),
@@ -93,7 +98,7 @@ class Slotted:
     (E,                             ':py:class:`~%s.E`\\[\\~T]' % __name__),
     (E[int],                        ':py:class:`~%s.E`\\[:py:class:`int`]' % __name__),
     (W,                             ':py:func:`~typing.NewType`\\(:py:data:`~W`, :py:class:`str`)')
-])
+], ids=str)
 def test_format_annotation(annotation, expected_result):
     result = format_annotation(annotation)
     assert result == expected_result
@@ -118,12 +123,12 @@ def test_format_annotation(annotation, expected_result):
     (Dict[T, U],                    ':py:class:`typing.Dict`\\[\\~T, \\+U]'),
     (Dict[str, bool],               ':py:class:`typing.Dict`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
-    (Tuple,                         ':py:class:`typing.Tuple`'),
-    (Tuple[str, bool],              ':py:class:`typing.Tuple`\\[:py:class:`str`, '
+    (Tuple,                         ':py:data:`typing.Tuple`'),
+    (Tuple[str, bool],              ':py:data:`typing.Tuple`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
-    (Tuple[int, int, int],          ':py:class:`typing.Tuple`\\[:py:class:`int`, '
+    (Tuple[int, int, int],          ':py:data:`typing.Tuple`\\[:py:class:`int`, '
                                     ':py:class:`int`, :py:class:`int`]'),
-    (Tuple[str, ...],               ':py:class:`typing.Tuple`\\[:py:class:`str`, ...]'),
+    (Tuple[str, ...],               ':py:data:`typing.Tuple`\\[:py:class:`str`, ...]'),
     (Union,                         ':py:data:`typing.Union`'),
     (Union[str, bool],              ':py:data:`typing.Union`\\[:py:class:`str`, '
                                     ':py:class:`bool`]'),
@@ -147,7 +152,7 @@ def test_format_annotation(annotation, expected_result):
     (E,                             ':py:class:`%s.E`\\[\\~T]' % __name__),
     (E[int],                        ':py:class:`%s.E`\\[:py:class:`int`]' % __name__),
     (W,                             ':py:func:`typing.NewType`\\(:py:data:`~W`, :py:class:`str`)')
-])
+], ids=str)
 def test_format_annotation_fully_qualified(annotation, expected_result):
     result = format_annotation(annotation, fully_qualified=True)
     assert result == expected_result


### PR DESCRIPTION
faa272c fixes #94, types that should be linked like ``:py:data:`typing.Tuple` `` instead of  `py:class`.

1f5e310 fixes #96, only `.title()`casing types that are builtins, such as `set`→`Set` and `dict`→`Dict`, but not `TextIO`→`Textio`.