### PR TITLE
Change detection if a typing.* item is py:data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ test =
     typing_extensions >= 3.5
     typed_ast >= 1.4.0
     dataclasses; python_version == "3.6"
+    sphobjinv >= 2.0
 
 [flake8]
 max-line-length = 99

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -1,5 +1,6 @@
 import inspect
 import textwrap
+import collections.abc
 import typing
 from typing import get_type_hints, TypeVar, Any, AnyStr, Generic, Union
 
@@ -12,7 +13,19 @@ except ImportError:
     Protocol = None
 
 logger = logging.getLogger(__name__)
-pydata_annotations = {'Any', 'AnyStr', 'Callable', 'ClassVar', 'NoReturn', 'Optional', 'Union'}
+# type(annotation)
+data_types = (
+    typing.TypeVar,
+    typing._VariadicGenericAlias,
+    typing._SpecialForm,
+)
+# annotation.__origin__
+data_origins = (
+    tuple,
+    collections.abc.Callable,
+    typing.ClassVar,
+    typing.Union,
+)
 
 
 def format_annotation(annotation, fully_qualified=False):
@@ -95,8 +108,10 @@ def format_annotation(annotation, fully_qualified=False):
             extra = '\\[{}]'.format(', '.join(
                 format_annotation(param, fully_qualified) for param in params))
 
+        data = annotation_cls in data_types or origin in data_origins
+
         return '{prefix}`{qualify}{module}.{name}`{extra}'.format(
-            prefix=':py:data:' if class_name in pydata_annotations else ':py:class:',
+            prefix=':py:data:' if data else ':py:class:',
             qualify="" if fully_qualified else "~",
             module=module,
             name=class_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,20 @@ import shutil
 
 import pytest
 from sphinx.testing.path import path
+from sphobjinv import Inventory
 
 pytest_plugins = 'sphinx.testing.fixtures'
 collect_ignore = ['roots']
+inv_cache = {}
+
+
+@pytest.fixture(params=["3.5", "3.6", "3.7"])
+def inv(request):
+    pyver = request.param
+    inv = inv_cache.get(pyver)
+    if not inv:
+        inv = inv_cache[pyver] = Inventory(url=f"https://docs.python.org/{pyver}/objects.inv")
+    return inv
 
 
 @pytest.fixture(autouse=True)
@@ -21,7 +32,6 @@ def remove_sphinx_projects(sphinx_test_tempdir):
                 shutil.rmtree(str(entry))
         except PermissionError:
             pass
-
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,8 @@ def inv(request):
     pyver = request.param
     inv = inv_cache.get(pyver)
     if not inv:
-        inv = inv_cache[pyver] = Inventory(url=f"https://docs.python.org/{pyver}/objects.inv")
+        url = "https://docs.python.org/{}/objects.inv".format(pyver)
+        inv = inv_cache[pyver] = Inventory(url=url)
     return inv
 
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -183,7 +183,7 @@ def test_format_annotation_fully_qualified(annotation, expected_result):
 
 @pytest.mark.parametrize('annotation, result', [
     a for a in annotations
-    if a[0] is not type(None)
+    if a[0] is not type(None)  # noqa
 ])
 def test_role_categories(inv, annotation, result):
     m = re.match('^:py:(?P<role>class|data|func):`(?P<name>[^`]+)`', result)


### PR DESCRIPTION
I only found an elegant way for plain types, i.e. ` AnyStr` (a `TypeVar`), `Any`/`NoReturn` (`_SpecialForm`s), and the non-subset versions of `Callable`/`Tuple` (`_VariadicGenericAlias`es) and `ClassVar`/`Optional`/`Union` (`_SpecialForm`s). As soon as you subset them, they all become `_GenericAlias`es:

```py
>>> {a: type(a) for a in [Callable[[], None], Tuple[str, int], ClassVar[str], Union[str, int]]}
{typing.Callable[[], NoneType]: typing._GenericAlias,
 typing.Tuple[str, int]: typing._GenericAlias,
 typing.ClassVar[str]: typing._GenericAlias,
 typing.Union[str, int]: typing._GenericAlias}
```

Sadly, other things become `_GenericAlias`es too, e.g. `type(typing.Generator[None, None, None])` → `typing._GenericAlias`, so we need to go over the information stored in the `_GenericAlias`: `_inst`, `_special`, `_name`, `__origin__`, and `__args__`. Of those, only `__origin__` and `_name` are of interest. `_name` is derived from `__origin__` using `typing._normalize_alias`, which maps `tuple`→`Tuple`, `defaultdict`→`DefaultDict` for display purposes.

Fixes #97