### PR TITLE
Default values mess up type comment argument detection

### DIFF
--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -186,13 +186,14 @@ class ClassWithTypehints(object):
         return 42
 
 
-def function_with_typehint_comment_not_inline(x=None, *y, **kwargs):
-    # type: (Union[str, bytes], *str, **int) -> None
+def function_with_typehint_comment_not_inline(x=None, *y, z, **kwargs):
+    # type: (Union[str, bytes], *str, bytes, **int) -> None
     """
     Function docstring.
 
     :param x: foo
     :param y: bar
+    :param z: baz
     :param kwargs: some kwargs
     """
 

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -186,7 +186,7 @@ class ClassWithTypehints(object):
         return 42
 
 
-def function_with_typehint_comment_not_inline(x, *y, **kwargs):
+def function_with_typehint_comment_not_inline(x=None, *y, **kwargs):
     # type: (Union[str, bytes], *str, **int) -> None
     """
     Function docstring.
@@ -204,11 +204,11 @@ class ClassWithTypehintsNotInline(object):
     :param x: foo
     """
 
-    def __init__(self, x):
+    def __init__(self, x=None):
         # type: (Callable[[int, bytes], int]) -> None
         pass
 
-    def foo(self, x):
+    def foo(self, x=1):
         # type: (Callable[[int, bytes], int]) -> int
         """
         Method docstring.
@@ -218,7 +218,7 @@ class ClassWithTypehintsNotInline(object):
         return x(1, b'')
 
     @classmethod
-    def mk(cls, x):
+    def mk(cls, x=None):
         # type: (Callable[[int, bytes], int]) -> ClassWithTypehintsNotInline
         """
         Method docstring.

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -413,12 +413,12 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Return type:
                  "int"
 
-        dummy_module.function_with_typehint_comment_not_inline(x, *y, **kwargs)
+        dummy_module.function_with_typehint_comment_not_inline(x=None, *y, **kwargs)
 
            Function docstring.
 
            Parameters:
-              * **x** ("Union"["str", "bytes"]) -- foo
+              * **x** ("Union"["str", "bytes", "None"]) -- foo
 
               * **y** ("str") -- bar
 
@@ -427,14 +427,14 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
            Return type:
               "None"
 
-        class dummy_module.ClassWithTypehintsNotInline(x)
+        class dummy_module.ClassWithTypehintsNotInline(x=None)
 
            Class docstring.
 
            Parameters:
-              **x** ("Callable"[["int", "bytes"], "int"]) -- foo
+              **x** ("Optional"["Callable"[["int", "bytes"], "int"]]) -- foo
 
-           foo(x)
+           foo(x=1)
 
               Method docstring.
 
@@ -444,7 +444,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Return type:
                  "int"
 
-           classmethod mk(x)
+           classmethod mk(x=None)
 
               Method docstring.
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -207,7 +207,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
     # There should be a warning about an unresolved forward reference
     warnings = warning.getvalue().strip()
-    assert 'Cannot resolve forward reference in type annotations of ' in warnings
+    assert 'Cannot resolve forward reference in type annotations of ' in warnings, warnings
 
     if always_document_param_types:
         undoc_params = '''
@@ -413,7 +413,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               Return type:
                  "int"
 
-        dummy_module.function_with_typehint_comment_not_inline(x=None, *y, **kwargs)
+        dummy_module.function_with_typehint_comment_not_inline(x=None, *y, z, **kwargs)
 
            Function docstring.
 
@@ -421,6 +421,8 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
               * **x** ("Union"["str", "bytes", "None"]) -- foo
 
               * **y** ("str") -- bar
+
+              * **z** ("bytes") -- baz
 
               * **kwargs** ("int") -- some kwargs
 


### PR DESCRIPTION
This fixes it by collecting them in the correct order. Validated with my project of 250+ type annotated functions.