### PR TITLE
Introduce typehints_document_rtype config.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ The following configuration options are accepted:
 * ``always_document_param_types`` (default: ``False``): If ``False``, do not add type info for
   undocumented parameters.  If ``True``, add stub documentation for undocumented parameters to
   be able to add type info.
+* ``typehints_document_rtype`` (default: ``True``): If ``False``, never add an ``:rtype:`` directive.
+  If ``True``, add the ``:rtype:`` directive if no existing ``:rtype:`` is found.
 
 
 How it works

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -392,7 +392,7 @@ def process_docstring(app, what, name, obj, options, lines):
                 elif line.startswith(':return:') or line.startswith(':returns:'):
                     insert_index = i
 
-            if insert_index is not None:
+            if insert_index is not None and app.config.typehints_document_rtype:
                 if insert_index == len(lines):
                     # Ensure that :rtype: doesn't get joined with a paragraph of text, which
                     # prevents it being interpreted.
@@ -411,6 +411,7 @@ def setup(app):
     app.add_config_value('set_type_checking_flag', False, 'html')
     app.add_config_value('always_document_param_types', False, 'html')
     app.add_config_value('typehints_fully_qualified', False, 'env')
+    app.add_config_value('typehints_document_rtype', True, 'env')
     app.connect('builder-inited', builder_ready)
     app.connect('autodoc-process-signature', process_signature)
     app.connect('autodoc-process-docstring', process_docstring)


### PR DESCRIPTION
If typehints_document_rtype=False (default True), never add an :rtype: directive.

Closes #106.