### PR TITLE
Support links for typing_extensions

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -25,7 +25,7 @@ def format_annotation(annotation, fully_qualified=False):
             return ':py:class:`{}`'.format(annotation.__qualname__)
 
     annotation_cls = annotation if inspect.isclass(annotation) else type(annotation)
-    if annotation_cls.__module__ == 'typing':
+    if annotation_cls.__module__ in {'typing', 'typing_extensions'}:
         class_name = str(annotation).split('[')[0].split('.')[-1]
         params = None
         module = 'typing'


### PR DESCRIPTION
Fixes part of #108. In Python 3.7, this will create links to the 3.8+ typing docs: https://docs.python.org/3/library/typing.html