### PR TITLE
Add support for union args on 3.7

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -73,6 +73,8 @@ def get_annotation_args(annotation, module: str, class_name: str) -> Tuple:
     elif class_name == 'Callable' and hasattr(annotation, '__result__'):  # Python < 3.5.3
         argtypes = (Ellipsis,) if annotation.__args__ is Ellipsis else annotation.__args__
         return argtypes + (annotation.__result__,)
+    elif class_name == 'Union' and hasattr(annotation, '__args__'):  # Union on Python 3.7
+        return annotation.__args__
     elif class_name == 'Union' and hasattr(annotation, '__union_params__'):  # Union on Python 3.5
         return annotation.__union_params__
     elif class_name == 'Tuple' and hasattr(annotation, '__tuple_params__'):  # Tuple on Python 3.5


### PR DESCRIPTION
On  3.7, the current union args will always be None, which raises an exception because `len(None)` is not allowed.

This changes it to look for `__args__` if its present.

Inspired by https://github.com/ilevkivskyi/typing_inspect/blob/45efedf7ea3c0debbed3a38ba0b43aefa346ff9a/typing_inspect.py#L335. I considered adding a dependency to typing_inspect, but this was previously ruled out https://github.com/agronholm/sphinx-autodoc-typehints/issues/82