### PR TITLE
Ignore indentation error on function parse

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -256,7 +256,7 @@ def backfill_type_hints(obj, name):
 
     try:
         obj_ast = ast.parse(textwrap.dedent(inspect.getsource(obj)), **parse_kwargs)
-    except (OSError, TypeError):
+    except (OSError, TypeError, IndentationError):
         return {}
 
     obj_ast = _one_child(obj_ast)


### PR DESCRIPTION
This allows to handle valid code like:
```
class MyClass:
    def my_method(self):
        a = '''long
string with bad indentation'''
        return a
```