### PR TITLE
get_annotation_class_name() not always returning string

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -110,6 +110,10 @@ def format_annotation(annotation, fully_qualified: bool = False) -> str:
     try:
         module = get_annotation_module(annotation)
         class_name = get_annotation_class_name(annotation, module)
+        if not isinstance(class_name, str):
+            print('annotation %r module %r class_name %r %r' % (
+                annotation, module, class_name, type(class_name)))
+            class_name = str(class_name)
         args = get_annotation_args(annotation, module, class_name)
     except ValueError:
         return str(annotation)


### PR DESCRIPTION
Under python3.8 I get the following crash:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/sphinx/events.py", line 110, in emit
    results.append(listener.handler(self.app, *args))
  File "/usr/local/lib/python3.8/dist-packages/sphinx_autodoc_typehints.py", line 374, in process_docstring
    formatted_annotation = format_annotation(
  File "/usr/local/lib/python3.8/dist-packages/sphinx_autodoc_typehints.py", line 146, in format_annotation
    formatted_args = args_format.format(', '.join(format_annotation(arg, fully_qualified)
  File "/usr/local/lib/python3.8/dist-packages/sphinx_autodoc_typehints.py", line 146, in <genexpr>
    formatted_args = args_format.format(', '.join(format_annotation(arg, fully_qualified)
  File "/usr/local/lib/python3.8/dist-packages/sphinx_autodoc_typehints.py", line 117, in format_annotation
    args = get_annotation_args(annotation, module, class_name)
  File "/usr/local/lib/python3.8/dist-packages/sphinx_autodoc_typehints.py", line 63, in get_annotation_args
    original = getattr(sys.modules[module], class_name)
TypeError: getattr(): attribute name must be string
```

I didn't get this under python 3.6 so I guess something changed between python 3.6 and 3.8?

It seems that `get_annotation_class_name()` isn't always returning a string? I added the code shown in the PR (an avoidance measure, not a fix) and now get this:

```
annotation typing.IO[str] module 'typing' class_name <property object at 0x7fb1c74402c0> <class 'property'>
```

This is coming (not surprisingly) from this in my python code:

```
dumpfd: IO[str]
```

Sorry, but I haven't narrowed it down further (as yet).