### PR TITLE
Update special dataclass handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import pathlib
 import shutil
@@ -42,3 +43,12 @@ def remove_sphinx_projects(sphinx_test_tempdir):
 @pytest.fixture
 def rootdir():
     return path(os.path.dirname(__file__) or '.').abspath() / 'roots'
+
+
+def pytest_ignore_collect(path, config):
+    version_re = re.compile(r'_py(\d)(\d)\.py$')
+    match = version_re.search(path.basename)
+    if match:
+        version = tuple(int(x) for x in match.groups())
+        if sys.version_info < version:
+            return True

--- a/tests/roots/test-dataclass/conf.py
+++ b/tests/roots/test-dataclass/conf.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+
+
+# Make dataclass_module.py available for autodoc.
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+
+master_doc = 'index'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
+    ]

--- a/tests/roots/test-dataclass/dataclass_module.py
+++ b/tests/roots/test-dataclass/dataclass_module.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DataClass:
+    """Class docstring."""
+
+    x: int

--- a/tests/roots/test-dataclass/index.rst
+++ b/tests/roots/test-dataclass/index.rst
@@ -1,0 +1,6 @@
+Dataclass Module
+================
+
+.. autoclass:: dataclass_module.DataClass
+    :undoc-members:
+    :special-members: __init__

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -235,13 +235,6 @@ def undocumented_function(x: int) -> str:
     return str(x)
 
 
-@dataclass
-class DataClass:
-    """Class docstring."""
-
-    x: int
-
-
 class Decorator:
     """
     Initializer docstring.

--- a/tests/roots/test-dummy/dummy_module.py
+++ b/tests/roots/test-dummy/dummy_module.py
@@ -239,6 +239,8 @@ def undocumented_function(x: int) -> str:
 class DataClass:
     """Class docstring."""
 
+    x: int
+
 
 class Decorator:
     """

--- a/tests/test_dataclass_py36.py
+++ b/tests/test_dataclass_py36.py
@@ -1,0 +1,48 @@
+import pathlib
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize('always_document_param_types', [True, False])
+@pytest.mark.sphinx('text', testroot='dataclass')
+def test_sphinx_output(app, status, warning, always_document_param_types):
+    test_path = pathlib.Path(__file__).parent
+
+    # Add test directory to sys.path to allow imports of dummy module.
+    if str(test_path) not in sys.path:
+        sys.path.insert(0, str(test_path))
+
+    app.config.always_document_param_types = always_document_param_types
+    app.build()
+
+    assert 'build succeeded' in status.getvalue()  # Build succeeded
+
+    format_args = {}
+    if always_document_param_types:
+        for indentation_level in range(3):
+            format_args['undoc_params_{}'.format(indentation_level)] = textwrap.indent(
+                '\n\n   Parameters:\n      **x** ("int") --', '   ' * indentation_level
+            )
+    else:
+        for indentation_level in range(3):
+            format_args['undoc_params_{}'.format(indentation_level)] = ''
+
+    text_path = pathlib.Path(app.srcdir) / '_build' / 'text' / 'index.txt'
+    with text_path.open('r') as f:
+        text_contents = f.read().replace('–', '--')
+        expected_contents = textwrap.dedent('''\
+        Dataclass Module
+        ****************
+
+        class dataclass_module.DataClass(x)
+
+           Class docstring.{undoc_params_0}
+
+           __init__(x)
+
+              Initialize self.  See help(type(self)) for accurate signature.{undoc_params_1}
+        ''')
+        expected_contents = expected_contents.format(**format_args).replace('–', '--')
+        assert text_contents == expected_contents

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -224,13 +224,9 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
     format_args = {}
     if always_document_param_types:
-        for indentation_level in range(3):
-            format_args['undoc_params_{}'.format(indentation_level)] = textwrap.indent(
-                '\n\n   Parameters:\n      **x** ("int") --', '   ' * indentation_level
-            )
+        format_args['undoc_params'] = '\n\n   Parameters:\n      **x** ("int") --'
     else:
-        for indentation_level in range(3):
-            format_args['undoc_params_{}'.format(indentation_level)] = ''
+        format_args['undoc_params'] = ''
 
     text_path = pathlib.Path(app.srcdir) / '_build' / 'text' / 'index.txt'
     with text_path.open('r') as f:
@@ -473,18 +469,10 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
         dummy_module.undocumented_function(x)
 
-           Hi{undoc_params_0}
+           Hi{undoc_params}
 
            Return type:
               "str"
-
-        class dummy_module.DataClass(x)
-
-           Class docstring.{undoc_params_0}
-
-           __init__(x)
-
-              Initialize self.  See help(type(self)) for accurate signature.{undoc_params_1}
 
         @dummy_module.Decorator(func)
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -224,9 +224,13 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
     format_args = {}
     if always_document_param_types:
-        format_args['undoc_params'] = '\n\n   Parameters:\n      **x** ("int") --'
+        for indentation_level in range(3):
+            format_args['undoc_params_{}'.format(indentation_level)] = textwrap.indent(
+                '\n\n   Parameters:\n      **x** ("int") --', '   ' * indentation_level
+            )
     else:
-        format_args['undoc_params'] = ""
+        for indentation_level in range(3):
+            format_args['undoc_params_{}'.format(indentation_level)] = ''
 
     text_path = pathlib.Path(app.srcdir) / '_build' / 'text' / 'index.txt'
     with text_path.open('r') as f:
@@ -469,18 +473,18 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
         dummy_module.undocumented_function(x)
 
-           Hi{undoc_params}
+           Hi{undoc_params_0}
 
            Return type:
               "str"
 
-        class dummy_module.DataClass
+        class dummy_module.DataClass(x)
 
-           Class docstring.
+           Class docstring.{undoc_params_0}
 
-           __init__()
+           __init__(x)
 
-              Initialize self.  See help(type(self)) for accurate signature.
+              Initialize self.  See help(type(self)) for accurate signature.{undoc_params_1}
 
         @dummy_module.Decorator(func)
 


### PR DESCRIPTION
The existing unit tests appear to catch this regression when running with a python version that exhibits this change, so I didn't add an additional protection.

Please let me know I'm missing anything in this patch. Thanks for a great tool!