### PR TITLE
Fix sphinx expected output test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ test =
     typing_extensions >= 3.5
     dataclasses; python_version == "3.6"
     sphobjinv >= 2.0
+    Sphinx >= 3.2.0
 type_comments =
     typed_ast >= 1.4.0; python_version < "3.8"
 

--- a/tests/test_sphinx_autodoc_typehints.py
+++ b/tests/test_sphinx_autodoc_typehints.py
@@ -250,7 +250,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
 
               Inner class.
 
-              _InnerClass__dunder_inner_method(x)
+              __dunder_inner_method(x)
 
                  Dunder inner method.
 
@@ -270,7 +270,7 @@ def test_sphinx_output(app, status, warning, always_document_param_types):
                  Return type:
                     "str"
 
-           _Class__dunder_method(x)
+           __dunder_method(x)
 
               Dunder method docstring.
 


### PR DESCRIPTION
Tests are failing on the `master` branch for this repository.
This is because Sphinx changed in `3.2.0`.

The test changed here (`test_sphinx_output`) relies on the old Sphinx behaviour.
The changes here are for parts of the document not modified by this package.