### PR TITLE
show (important) errors for get_type_hints(obj)

### DIFF
--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -231,7 +231,7 @@ def get_all_type_hints(obj, name):
     except (AttributeError, TypeError, RecursionError):
         # Introspecting a slot wrapper will raise TypeError, and and some recursive type
         # definitions will cause a RecursionError (https://github.com/python/typing/issues/574).
-        pass
+        logger.exception(f"error during get_type_hints({obj}) %s", e, exc_info=True)
     except NameError as exc:
         logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',
                        name, exc)

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -228,7 +228,7 @@ def get_all_type_hints(obj, name):
 
     try:
         rv = get_type_hints(obj)
-    except (AttributeError, TypeError, RecursionError):
+    except (AttributeError, TypeError, RecursionError) as e:
         # Introspecting a slot wrapper will raise TypeError, and and some recursive type
         # definitions will cause a RecursionError (https://github.com/python/typing/issues/574).
         logger.exception(f"error during get_type_hints({obj}) %s", e, exc_info=True)

--- a/sphinx_autodoc_typehints.py
+++ b/sphinx_autodoc_typehints.py
@@ -231,7 +231,7 @@ def get_all_type_hints(obj, name):
     except (AttributeError, TypeError, RecursionError) as e:
         # Introspecting a slot wrapper will raise TypeError, and and some recursive type
         # definitions will cause a RecursionError (https://github.com/python/typing/issues/574).
-        logger.exception(f"error during get_type_hints({obj}) %s", e, exc_info=True)
+        logger.exception("error during get_type_hints({obj}) %s".format(obj=obj), e, exc_info=True)
     except NameError as exc:
         logger.warning('Cannot resolve forward reference in type annotations of "%s": %s',
                        name, exc)


### PR DESCRIPTION
The exceptions could contain important informations for the users like this
TypeError: TypeError: Forward references must evaluate to types. Got ...

This greatly helps during debugging documentation issues.